### PR TITLE
delete duplicate keys to squelch runtime warnings

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,16 +1,6 @@
 ---
 galaxy_info:
   author: Owen Barton
-  company: CivicActions
-  license: BSD
-  min_ansible_version: 2.2
-  platforms:
-  - name: EL
-    versions:
-    - 6
-    - 7
-  galaxy_tags:
-    - system
   description: Role to LVM partition a prepared EC2 instance. Generally called from the main ansible-ec2-800-53 role (https://github.com/CivicActions/ansible-ec2-800-53/).
   company: CivicActions
   license: BSD


### PR DESCRIPTION
Every time a playbook that references this is called we get multiple warnings about repeated dict keys. This change removes those.